### PR TITLE
Update simplified_main.py

### DIFF
--- a/simplified_scrapy/simplified_main.py
+++ b/simplified_scrapy/simplified_main.py
@@ -2,7 +2,7 @@
 #coding=utf-8
 import logging
 import threading, traceback, time, importlib, os, json, io
-from imp import reload
+from importlib import reload
 from simplified_scrapy.dictex import Dict
 from concurrent.futures import ThreadPoolExecutor
 from simplified_scrapy.core.utils import printInfo, getFileModifyTime, isExistsFile, getTimeNow, appendFile

--- a/simplified_scrapy/simplified_main.py
+++ b/simplified_scrapy/simplified_main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #coding=utf-8
 import logging
-import threading, traceback, time, importlib, imp, os, json, io
+import threading, traceback, time, importlib, os, json, io
 from imp import reload
 from simplified_scrapy.dictex import Dict
 from concurrent.futures import ThreadPoolExecutor


### PR DESCRIPTION
imp is being deprecated

```
DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import threading, traceback, time, importlib, imp, os, json, io

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```